### PR TITLE
Add support for images that use the palette of the previous image

### DIFF
--- a/TXG.cs
+++ b/TXG.cs
@@ -164,7 +164,18 @@ namespace TXG2TPL
             {
                 for (int i = 0; i < ImageCount; i++)
                 {
-                    PaletteData[i] = reader.ReadBytes(0x200, (int)reader.ReadUInt32());
+                    int palleteLength = (int)reader.ReadUInt32();
+                    if (palleteLength != -1)
+                    {
+                        PaletteData[i] = reader.ReadBytes(0x200, palleteLength);
+                    }
+                    else
+                    {
+                        // Use previous image's palette
+                        int previousPaletteLength = PaletteData[i - 1].Length;
+                        PaletteData[i] = new byte[previousPaletteLength];
+                        Array.Copy(PaletteData[i - 1], PaletteData[i], previousPaletteLength);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When reading palette data of an image, it is possible for the image to have the length of its palette data set to 0xFFFFFFFF (-1). This effectively means that it is using the palette of the previous image, likely to save space. I've added a check for -1 length. When that occurs, copy the palette data of the previous image to the palette data of the current image.

The other change in this commit is a change to make the line endings for `Catch unhandled exceptions when packing` consistent with the rest of TXG2TPL. This means using LF (line feed) instead of CRLF (carriage return followed by a line feed). See https://en.wikipedia.org/wiki/Newline#Representation for more information regarding this.
